### PR TITLE
Rename provider to src

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
-name = "accelerate-provider"
-version = "0.2.1"
+name = "accelerate-src"
+version = "0.3.0"
 license = "Apache-2.0/MIT"
 authors = ["Andrew Straw <strawman@astraw.com>"]
 description = "The package provides BLAS and LAPACK using Apple’s Accelerate framework."
-homepage = "https://github.com/strawlab/accelerate-provider"
-repository = "https://github.com/strawlab/accelerate-provider"
+homepage = "https://github.com/strawlab/accelerate-src"
+repository = "https://github.com/strawlab/accelerate-src"
 readme = "README.md"
 build = "build.rs"
+links = "Accelerate.framework"
 
 [dev-dependencies]
 libc = "0.2"

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -11,7 +11,7 @@ The following two notices apply to every file of the project.
 ## The Apache License
 
 ```
-Copyright 2015–2016 The accelerate-provider Developers
+Copyright 2015–2016 The accelerate-src Developers
 
 Licensed under the Apache License, Version 2.0 (the “License”); you may not use
 this file except in compliance with the License. You may obtain a copy of the
@@ -28,7 +28,7 @@ specific language governing permissions and limitations under the License.
 ## The MIT License
 
 ```
-Copyright 2015–2016 The accelerate-provider Developers
+Copyright 2015–2016 The accelerate-src Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the “Software”), to deal in

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Accelerate Provider [![Version][version-img]][version-url] [![Status][status-img]][status-url]
+# accelerate-src [![Version][version-img]][version-url] [![Status][status-img]][status-url]
 
 The package provides [BLAS][1] and [LAPACK][2] using Apple’s [Accelerate
 framework][3]. The framework is shipped with Mac OS X, and the package only
@@ -26,7 +26,7 @@ will be licensed according to the terms given in [LICENSE.md](LICENSE.md).
 [6]: https://github.com/stainless-steel/blas
 [7]: https://github.com/stainless-steel/lapack
 
-[version-img]: https://img.shields.io/crates/v/accelerate-provider.svg
-[version-url]: https://crates.io/crates/accelerate-provider
-[status-img]: https://travis-ci.org/strawlab/accelerate-provider.svg?branch=master
-[status-url]: https://travis-ci.org/strawlab/accelerate-provider
+[status-img]: https://travis-ci.org/strawlab/accelerate-src.svg?branch=master
+[status-url]: https://travis-ci.org/strawlab/accelerate-src
+[version-img]: https://img.shields.io/crates/v/accelerate-src.svg
+[version-url]: https://crates.io/crates/accelerate-src

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,9 +1,9 @@
 #![allow(non_camel_case_types)]
 
-extern crate accelerate_provider;
+extern crate accelerate_src;
 extern crate libc;
 
-use libc::{c_float, size_t, ptrdiff_t};
+use libc::{c_float, ptrdiff_t, size_t};
 
 extern "C" {
     fn vDSP_vsmul(vDSP_input1: *const c_float, vDSP_stride1: ptrdiff_t,


### PR DESCRIPTION
Please have a look at the discussion [here](https://github.com/cmr/openblas-src/issues/13). Could you please also rename the repository to `accelerate-src` and publish a new crate?

P.S. I’ve also added `links` to `Cargo.toml`, which I took from [`core-foundation-sys`](https://github.com/servo/core-foundation-rs/blob/master/core-foundation-sys/Cargo.toml).
