### PR TITLE
Bumping libc for aarch64 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ build = "build.rs"
 links = "Accelerate.framework"
 
 [dev-dependencies]
-libc = "0.2"
+libc = "0.2.86"


### PR DESCRIPTION
Libc linking is broken below the more recent versions on aarch64. See https://github.com/uutils/coreutils/pull/1724